### PR TITLE
Add account management and Stripe billing screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ HomeDoc is a React Native application that helps you document and manage your pr
 - Create notes with text and images
 - Modern, clean UI with a light purple theme
 - Cross-platform (iOS, Android, and Web)
+- Manage user account details
+- Placeholder billing flow powered by Stripe
 
 ## Getting Started
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-native-screens": "^4.11.1",
     "react-native-svg": "^15.12.0",
     "react-native-vector-icons": "^10.2.0",
-    "react-native-web": "^0.20.0"
+    "react-native-web": "^0.20.0",
+    "@stripe/stripe-react-native": "^0.7.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -4,7 +4,7 @@ import Svg, { Path } from 'react-native-svg';
 import { theme } from '../utils/theme';
 
 type IconProps = {
-  name: 'home' | 'area' | 'note' | 'add';
+  name: 'home' | 'area' | 'note' | 'add' | 'user';
   size?: number;
   color?: string;
 };
@@ -14,6 +14,8 @@ const iconPaths = {
   area: 'M3 3H21V21H3V3ZM3 9H21ZM9 3V21',
   note: 'M14 2H6C5.46957 2 4.96086 2.21071 4.58579 2.58579C4.21071 2.96086 4 3.46957 4 4V20C4 20.5304 4.21071 21.0391 4.58579 21.4142C4.96086 21.7893 5.46957 22 6 22H18C18.5304 22 19.0391 21.7893 19.4142 21.4142C19.7893 21.0391 20 20.5304 20 20V8L14 2ZM14 2V8H20ZM16 13H8ZM16 17H8ZM10 9H9H8',
   add: 'M12 5V19M5 12H19',
+  user:
+    'M12 12C14.2091 12 16 10.2091 16 8C16 5.79086 14.2091 4 12 4C9.79086 4 8 5.79086 8 8C8 10.2091 9.79086 12 12 12ZM4 20V18C4 15.7909 7.58172 14 12 14C16.4183 14 20 15.7909 20 18V20',
 };
 
 export const Icon: React.FC<IconProps> = ({ name, size = 24, color = theme.colors.text.primary }) => {

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -17,6 +17,8 @@ import EditNoteScreen from '../screens/EditNoteScreen';
 import EditPropertyScreen from '../screens/EditPropertyScreen';
 import EditAreaScreen from '../screens/EditAreaScreen';
 import TransferPropertyScreen from '../screens/TransferPropertyScreen';
+import AccountScreen from '../screens/AccountScreen';
+import PlanManagementScreen from '../screens/PlanManagementScreen';
 
 export type RootStackParamList = {
   Main: undefined;
@@ -27,6 +29,7 @@ export type RootStackParamList = {
   EditProperty: { propertyId: string };
   EditArea: { areaId: string };
   TransferProperty: { propertyId: string };
+  PlanManagement: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -80,6 +83,15 @@ const MainTabs = () => {
         options={{
           tabBarIcon: ({ color, size }) => (
             <Icon name="note" color={color} size={size} />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="Account"
+        component={AccountScreen}
+        options={{
+          tabBarIcon: ({ color, size }) => (
+            <Icon name="user" color={color} size={size} />
           ),
         }}
       />
@@ -159,7 +171,14 @@ export const AppNavigator = () => {
             title: 'Transfer Property',
           }}
         />
+        <Stack.Screen
+          name="PlanManagement"
+          component={PlanManagementScreen}
+          options={{
+            title: 'Plan Management',
+          }}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   );
-}; 
+};

--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { View, StyleSheet, ScrollView } from 'react-native';
+import { Text, Input, Button } from '@rneui/themed';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation/AppNavigator';
+import { mockUser } from '../mock/data';
+import { theme } from '../utils/theme';
+
+export type AccountScreenProps = {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'Main'>;
+};
+
+const AccountScreen: React.FC<AccountScreenProps> = ({ navigation }) => {
+  const [name, setName] = useState(mockUser.name);
+  const [email, setEmail] = useState(mockUser.email);
+
+  const handleSave = () => {
+    // In a real app, this would update the user profile in the database
+    console.log('Saving user info', { name, email });
+  };
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.header}>Account</Text>
+      <Input
+        label="Name"
+        value={name}
+        onChangeText={setName}
+        placeholder="Enter your name"
+        inputContainerStyle={styles.inputContainer}
+      />
+      <Input
+        label="Email"
+        value={email}
+        onChangeText={setEmail}
+        placeholder="Enter your email"
+        keyboardType="email-address"
+        inputContainerStyle={styles.inputContainer}
+      />
+      <Button title="Save" onPress={handleSave} containerStyle={styles.button} />
+      <Button
+        title="Manage Plan"
+        type="outline"
+        onPress={() => navigation.navigate('PlanManagement')}
+        containerStyle={styles.button}
+      />
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background.default,
+  },
+  content: {
+    padding: theme.spacing.md,
+  },
+  header: {
+    fontSize: theme.typography.h2.fontSize,
+    fontWeight: 'bold',
+    color: theme.colors.text.primary,
+    marginBottom: theme.spacing.md,
+  },
+  inputContainer: {
+    paddingHorizontal: theme.spacing.sm,
+    paddingVertical: theme.spacing.xs,
+  },
+  button: {
+    marginTop: theme.spacing.sm,
+  },
+});
+
+export default AccountScreen;

--- a/src/screens/PlanManagementScreen.tsx
+++ b/src/screens/PlanManagementScreen.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Text, Button, Card } from '@rneui/themed';
+import { initializeStripe, checkoutWithStripe } from '../utils/stripe';
+import { theme } from '../utils/theme';
+
+const PlanManagementScreen: React.FC = () => {
+  const handleUpgrade = async () => {
+    initializeStripe();
+    // In a real app, checkoutWithStripe would open a Stripe checkout flow
+    await checkoutWithStripe();
+  };
+
+  return (
+    <View style={styles.container}>
+      <Card containerStyle={styles.card}>
+        <Card.Title style={styles.title}>Pro Plan</Card.Title>
+        <Text style={styles.description}>Unlock advanced features for $9.99/month.</Text>
+        <Button title="Upgrade with Stripe" onPress={handleUpgrade} containerStyle={styles.button} />
+      </Card>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background.default,
+    justifyContent: 'center',
+  },
+  card: {
+    borderRadius: theme.borderRadius.md,
+    backgroundColor: theme.colors.background.paper,
+  },
+  title: {
+    fontSize: theme.typography.h3.fontSize,
+    color: theme.colors.text.primary,
+    marginBottom: theme.spacing.sm,
+  },
+  description: {
+    fontSize: theme.typography.body1.fontSize,
+    color: theme.colors.text.secondary,
+    marginBottom: theme.spacing.md,
+    textAlign: 'center',
+  },
+  button: {
+    marginTop: theme.spacing.sm,
+  },
+});
+
+export default PlanManagementScreen;

--- a/src/utils/stripe.ts
+++ b/src/utils/stripe.ts
@@ -1,0 +1,10 @@
+// Placeholder Stripe integration
+// In a real application you would configure publishable keys and use the
+// stripe-react-native library APIs here.
+export const initializeStripe = () => {
+  console.log('Initializing Stripe');
+};
+
+export const checkoutWithStripe = async () => {
+  console.log('Starting Stripe checkout');
+};


### PR DESCRIPTION
## Summary
- allow users to modify account details
- add plan management screen with placeholder Stripe checkout
- show account screen in bottom tabs
- wire plan management into navigation
- support user icon in Icon component
- add Stripe package
- document account and billing features in README

## Testing
- `npx tsc --noEmit` *(fails: several type errors)*

------
https://chatgpt.com/codex/tasks/task_b_683e8785053c8328b674923a69f4b3e4