### PR TITLE
Enable Supabase integration for areas and notes

### DIFF
--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -42,60 +42,86 @@ export const useProperties = (userId: string | undefined) => {
   return { properties, loading, error, refetch };
 };
 
-export const useAreas = (propertyId: string) => {
+export const useAreas = (propertyId: string | undefined) => {
   const [areas, setAreas] = useState<Area[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const fetchAreas = async () => {
+    if (!propertyId) {
+      setAreas([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      const { data, error } = await supabase
+        .from('areas')
+        .select('*')
+        .eq('property_id', propertyId);
+
+      if (error) throw error;
+      setAreas(data || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
-    const fetchAreas = async () => {
-      try {
-        const { data, error } = await supabase
-          .from('areas')
-          .select('*')
-          .eq('property_id', propertyId);
-
-        if (error) throw error;
-        setAreas(data || []);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'An error occurred');
-      } finally {
-        setLoading(false);
-      }
-    };
-
     fetchAreas();
   }, [propertyId]);
 
-  return { areas, loading, error };
+  const refetch = () => {
+    fetchAreas();
+  };
+
+  return { areas, loading, error, refetch };
 };
 
-export const useNotes = (areaId: string) => {
+export const useNotes = (areaId: string | undefined) => {
   const [notes, setNotes] = useState<Note[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const fetchNotes = async () => {
+    if (!areaId) {
+      setNotes([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      const { data, error } = await supabase
+        .from('notes')
+        .select('*')
+        .eq('area_id', areaId);
+
+      if (error) throw error;
+      setNotes(data || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
-    const fetchNotes = async () => {
-      try {
-        const { data, error } = await supabase
-          .from('notes')
-          .select('*')
-          .eq('area_id', areaId);
-
-        if (error) throw error;
-        setNotes(data || []);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'An error occurred');
-      } finally {
-        setLoading(false);
-      }
-    };
-
     fetchNotes();
   }, [areaId]);
 
-  return { notes, loading, error };
+  const refetch = () => {
+    fetchNotes();
+  };
+
+  return { notes, loading, error, refetch };
 };
 
 export const useProperty = (propertyId: string | undefined) => {
@@ -138,4 +164,170 @@ export const useProperty = (propertyId: string | undefined) => {
   };
 
   return { property, loading, error, refetch };
-}; 
+};
+
+export const useArea = (areaId: string | undefined) => {
+  const [area, setArea] = useState<Area | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchArea = async () => {
+    if (!areaId) {
+      setArea(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      const { data, error } = await supabase
+        .from('areas')
+        .select('*')
+        .eq('id', areaId)
+        .single();
+
+      if (error) throw error;
+      setArea(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchArea();
+  }, [areaId]);
+
+  const refetch = () => {
+    fetchArea();
+  };
+
+  return { area, loading, error, refetch };
+};
+
+export const useNote = (noteId: string | undefined) => {
+  const [note, setNote] = useState<Note | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchNote = async () => {
+    if (!noteId) {
+      setNote(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      const { data, error } = await supabase
+        .from('notes')
+        .select('*')
+        .eq('id', noteId)
+        .single();
+
+      if (error) throw error;
+      setNote(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchNote();
+  }, [noteId]);
+
+  const refetch = () => {
+    fetchNote();
+  };
+
+  return { note, loading, error, refetch };
+};
+
+export const useAllAreas = (userId: string | undefined) => {
+  const [areas, setAreas] = useState<Area[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAreas = async () => {
+    if (!userId) {
+      setAreas([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      const { data, error } = await supabase
+        .from('areas')
+        .select('*, properties!inner(name, id)')
+        .eq('properties.user_id', userId);
+
+      if (error) throw error;
+      setAreas((data as any) || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAreas();
+  }, [userId]);
+
+  const refetch = () => {
+    fetchAreas();
+  };
+
+  return { areas, loading, error, refetch };
+};
+
+export const useAllNotes = (userId: string | undefined) => {
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchNotes = async () => {
+    if (!userId) {
+      setNotes([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      const { data, error } = await supabase
+        .from('notes')
+        .select('*, areas!inner(property_id), areas(properties!inner(user_id))')
+        .eq('areas.properties.user_id', userId);
+
+      if (error) throw error;
+      setNotes((data as any) || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchNotes();
+  }, [userId]);
+
+  const refetch = () => {
+    fetchNotes();
+  };
+
+  return { notes, loading, error, refetch };
+};

--- a/src/screens/NoteScreen.tsx
+++ b/src/screens/NoteScreen.tsx
@@ -4,8 +4,8 @@ import { Text, Button } from '@rneui/themed';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RouteProp } from '@react-navigation/native';
 import { RootStackParamList } from '../navigation/AppNavigator';
-import { mockProperties } from '../mock/data';
 import { theme } from '../utils/theme';
+import { useNote } from '../hooks/useData';
 
 type NoteScreenProps = {
   navigation: NativeStackNavigationProp<RootStackParamList, 'Note'>;
@@ -13,10 +13,23 @@ type NoteScreenProps = {
 };
 
 const NoteScreen: React.FC<NoteScreenProps> = ({ navigation, route }) => {
-  const note = mockProperties
-    .flatMap((p) => p.areas)
-    .flatMap((a) => a.notes)
-    .find((n) => n.id === route.params.noteId);
+  const { note, loading, error } = useNote(route.params.noteId);
+
+  if (loading) {
+    return (
+      <View style={styles.container}>
+        <Text>Loading note...</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.container}>
+        <Text>Error: {error}</Text>
+      </View>
+    );
+  }
 
   if (!note) {
     return (
@@ -31,10 +44,10 @@ const NoteScreen: React.FC<NoteScreenProps> = ({ navigation, route }) => {
       <View style={styles.header}>
         <Text style={styles.title}>{note.title}</Text>
         <Text style={styles.date}>
-          Created: {new Date(note.createdAt).toLocaleDateString()}
+          Created: {new Date(note.created_at).toLocaleDateString()}
         </Text>
         <Text style={styles.date}>
-          Updated: {new Date(note.updatedAt).toLocaleDateString()}
+          Updated: {new Date(note.updated_at).toLocaleDateString()}
         </Text>
       </View>
       <View style={styles.content}>
@@ -101,7 +114,7 @@ const styles = StyleSheet.create({
   },
   image: {
     width: '100%',
-    aspectRatio: 16/9,
+    aspectRatio: 16 / 9,
     borderRadius: theme.borderRadius.md,
     marginBottom: theme.spacing.sm,
   },
@@ -110,4 +123,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default NoteScreen; 
+export default NoteScreen;

--- a/src/screens/PropertyScreen.tsx
+++ b/src/screens/PropertyScreen.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { View, StyleSheet, FlatList, TouchableOpacity, Image, ScrollView } from 'react-native';
+import {
+  View,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  Image,
+  ScrollView,
+} from 'react-native';
 import { Text, Button, Icon, FAB } from '@rneui/themed';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RouteProp } from '@react-navigation/native';
@@ -12,9 +19,21 @@ type PropertyScreenProps = {
   route: RouteProp<RootStackParamList, 'Property'>;
 };
 
-const PropertyScreen: React.FC<PropertyScreenProps> = ({ navigation, route }) => {
-  const { property, loading: propertyLoading, error: propertyError } = useProperty(route.params.propertyId);
-  const { areas, loading: areasLoading, error: areasError } = useAreas(route.params.propertyId);
+const PropertyScreen: React.FC<PropertyScreenProps> = ({
+  navigation,
+  route,
+}) => {
+  const {
+    property,
+    loading: propertyLoading,
+    error: propertyError,
+  } = useProperty(route.params.propertyId);
+  const {
+    areas,
+    loading: areasLoading,
+    error: areasError,
+    refetch: refetchAreas,
+  } = useAreas(route.params.propertyId);
 
   if (propertyLoading) {
     return (
@@ -56,23 +75,50 @@ const PropertyScreen: React.FC<PropertyScreenProps> = ({ navigation, route }) =>
             <Text style={styles.address}>
               {property.address_line_1}
               {property.address_line_2 && `, ${property.address_line_2}`}
-              {'\n'}{property.city}, {property.state} {property.zip_code}
+              {'\n'}
+              {property.city}, {property.state} {property.zip_code}
             </Text>
             <View style={styles.headerActions}>
               <Button
-                icon={<Icon name="edit" color={theme.colors.text.primary} style={styles.iconButton}/>}
+                icon={
+                  <Icon
+                    name="edit"
+                    color={theme.colors.text.primary}
+                    style={styles.iconButton}
+                  />
+                }
                 type="clear"
-                onPress={() => navigation.navigate('EditProperty', { propertyId: property.id })}
+                onPress={() =>
+                  navigation.navigate('EditProperty', {
+                    propertyId: property.id,
+                  })
+                }
                 buttonStyle={styles.actionButton}
               />
               <Button
-                icon={<Icon name="swap-horiz" color={theme.colors.text.primary} style={styles.iconButton}/>}
+                icon={
+                  <Icon
+                    name="swap-horiz"
+                    color={theme.colors.text.primary}
+                    style={styles.iconButton}
+                  />
+                }
                 type="clear"
-                onPress={() => navigation.navigate('TransferProperty', { propertyId: property.id })}
+                onPress={() =>
+                  navigation.navigate('TransferProperty', {
+                    propertyId: property.id,
+                  })
+                }
                 buttonStyle={styles.actionButton}
               />
               <Button
-                icon={<Icon name="delete" color={theme.colors.error.main} style={styles.iconButton}/>}
+                icon={
+                  <Icon
+                    name="delete"
+                    color={theme.colors.error.main}
+                    style={styles.iconButton}
+                  />
+                }
                 type="clear"
                 onPress={() => {
                   // In a real app, this would show a confirmation dialog
@@ -83,7 +129,7 @@ const PropertyScreen: React.FC<PropertyScreenProps> = ({ navigation, route }) =>
             </View>
           </View>
         </View>
-        
+
         {areasLoading ? (
           <View style={styles.loadingContainer}>
             <Text>Loading areas...</Text>
@@ -94,12 +140,16 @@ const PropertyScreen: React.FC<PropertyScreenProps> = ({ navigation, route }) =>
           </View>
         ) : areas.length === 0 ? (
           <View style={styles.emptyContainer}>
-            <Text style={styles.emptyText}>No areas added yet. Tap the + button to add an area.</Text>
+            <Text style={styles.emptyText}>
+              No areas added yet. Tap the + button to add an area.
+            </Text>
           </View>
         ) : (
           <FlatList
             data={areas}
             keyExtractor={(item) => item.id}
+            refreshing={areasLoading}
+            onRefresh={refetchAreas}
             renderItem={({ item }) => (
               <TouchableOpacity
                 onPress={() => navigation.navigate('Area', { areaId: item.id })}
@@ -117,16 +167,27 @@ const PropertyScreen: React.FC<PropertyScreenProps> = ({ navigation, route }) =>
                     <Text style={styles.areaTitle}>{item.name}</Text>
                     <View style={styles.cardActions}>
                       <Button
-                        icon={<Icon name="edit" color={theme.colors.text.primary} size={16} />}
+                        icon={
+                          <Icon
+                            name="edit"
+                            color={theme.colors.text.primary}
+                            size={16}
+                          />
+                        }
                         type="clear"
-                        onPress={() => {
-                          // In a real app, this would navigate to an edit area screen
-                          console.log('Edit area pressed');
-                        }}
+                        onPress={() =>
+                          navigation.navigate('EditArea', { areaId: item.id })
+                        }
                         buttonStyle={styles.actionButton}
                       />
                       <Button
-                        icon={<Icon name="delete" color={theme.colors.error.main} size={16} />}
+                        icon={
+                          <Icon
+                            name="delete"
+                            color={theme.colors.error.main}
+                            size={16}
+                          />
+                        }
                         type="clear"
                         onPress={() => {
                           // In a real app, this would show a confirmation dialog
@@ -144,7 +205,9 @@ const PropertyScreen: React.FC<PropertyScreenProps> = ({ navigation, route }) =>
         )}
       </ScrollView>
       <FAB
-        icon={<Icon name="add" size={24} color={theme.colors.background.paper} />}
+        icon={
+          <Icon name="add" size={24} color={theme.colors.background.paper} />
+        }
         placement="right"
         color={theme.colors.accent.main}
         onPress={() => {
@@ -254,4 +317,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default PropertyScreen; 
+export default PropertyScreen;


### PR DESCRIPTION
## Summary
- update data hooks with area and note helpers
- integrate Supabase for single area/note fetch and full lists
- refactor AreaScreen and PropertyScreen to support refresh and editing
- implement Supabase-backed edit screens for areas and notes
- display all areas and notes from Supabase

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684b46150c348328af257f216c470c72