### PR TITLE
Implement request quote workflow

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -20,6 +20,7 @@ import EditPropertyScreen from '../screens/EditPropertyScreen';
 import EditAreaScreen from '../screens/EditAreaScreen';
 import TransferPropertyScreen from '../screens/TransferPropertyScreen';
 import CreatePropertyScreen from '../screens/CreatePropertyScreen';
+import RequestQuoteScreen from '../screens/RequestQuoteScreen';
 
 export type RootStackParamList = {
   Main: undefined;
@@ -31,6 +32,7 @@ export type RootStackParamList = {
   EditArea: { areaId: string };
   TransferProperty: { propertyId: string };
   CreateProperty: undefined;
+  RequestQuote: { todoId: string };
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -179,6 +181,13 @@ export const AppNavigator = () => {
           component={CreatePropertyScreen}
           options={{
             title: 'Add Property',
+          }}
+        />
+        <Stack.Screen
+          name="RequestQuote"
+          component={RequestQuoteScreen}
+          options={{
+            title: 'Request Quotes',
           }}
         />
       </Stack.Navigator>

--- a/src/screens/AreaScreen.tsx
+++ b/src/screens/AreaScreen.tsx
@@ -134,6 +134,14 @@ const AreaScreen: React.FC<AreaScreenProps> = ({ navigation, route }) => {
                 <Text style={styles.content}>{item.pricing}</Text>
               )}
               {item.plan && <Text style={styles.content}>{item.plan}</Text>}
+              <Button
+                title="Get Quotes"
+                type="outline"
+                onPress={() =>
+                  navigation.navigate('RequestQuote', { todoId: item.id })
+                }
+                buttonStyle={styles.quoteButton}
+              />
             </View>
           )}
         />
@@ -220,6 +228,9 @@ const styles = StyleSheet.create({
   date: {
     color: theme.colors.text.primary,
     fontSize: theme.typography.caption.fontSize,
+  },
+  quoteButton: {
+    marginTop: theme.spacing.sm,
   },
   fab: {
     position: 'absolute',

--- a/src/screens/RequestQuoteScreen.tsx
+++ b/src/screens/RequestQuoteScreen.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from 'react';
+import {
+  View,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  Image,
+  Alert,
+} from 'react-native';
+import { Text, Input, Button } from '@rneui/themed';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RouteProp } from '@react-navigation/native';
+import * as ImagePicker from 'expo-image-picker';
+import { RootStackParamList } from '../navigation/AppNavigator';
+import { mockProperties } from '../mock/data';
+import { requestQuotes } from '../utils/quoteService';
+import { theme } from '../utils/theme';
+
+interface Props {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'RequestQuote'>;
+  route: RouteProp<RootStackParamList, 'RequestQuote'>;
+}
+
+const RequestQuoteScreen: React.FC<Props> = ({ navigation, route }) => {
+  const todo = mockProperties
+    .flatMap((p) => p.areas)
+    .flatMap((a) => a.todos)
+    .find((t) => t.id === route.params.todoId);
+
+  const property = mockProperties.find((p) =>
+    p.areas.some((a) => a.todos.some((t) => t.id === route.params.todoId)),
+  );
+
+  const [title, setTitle] = useState(todo?.title ?? '');
+  const [description, setDescription] = useState(todo?.context ?? '');
+  const [zip, setZip] = useState(property?.zip_code ?? '');
+  const [images, setImages] = useState<string[]>([]);
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsMultipleSelection: true,
+    });
+    if (!result.canceled) {
+      const uris = result.assets.map((a) => a.uri);
+      setImages((prev) => [...prev, ...uris]);
+    }
+  };
+
+  const submit = async () => {
+    try {
+      const data = await requestQuotes({ title, description, zip, images });
+      if (data.diyEstimate) {
+        Alert.alert('DIY Estimate', data.diyEstimate);
+      }
+      const msg = [
+        `Texted: ${data.smsResults.length}`,
+        `Called: ${data.callResults.length}`,
+        `Emailed: ${data.emailResults.length}`,
+      ].join('\n');
+      Alert.alert('Requests Sent', msg);
+      navigation.goBack();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <ScrollView style={styles.container}>
+      <Input
+        label="Job Title"
+        value={title}
+        onChangeText={setTitle}
+        inputContainerStyle={styles.inputContainer}
+      />
+      <Input
+        label="Description"
+        value={description}
+        onChangeText={setDescription}
+        inputContainerStyle={styles.inputContainer}
+        multiline
+      />
+      <Input
+        label="Zip Code"
+        value={zip}
+        onChangeText={setZip}
+        keyboardType="number-pad"
+        inputContainerStyle={styles.inputContainer}
+      />
+      <View style={styles.imageContainer}>
+        {images.map((uri, idx) => (
+          <Image key={idx} source={{ uri }} style={styles.image} />
+        ))}
+        <TouchableOpacity style={styles.addImage} onPress={pickImage}>
+          <Text style={styles.addImageText}>+</Text>
+        </TouchableOpacity>
+      </View>
+      <Button title="Request Quotes" onPress={submit} />
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background.default,
+    padding: theme.spacing.md,
+  },
+  inputContainer: {
+    paddingHorizontal: theme.spacing.sm,
+  },
+  imageContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: theme.spacing.sm,
+    marginBottom: theme.spacing.md,
+  },
+  image: {
+    width: 80,
+    height: 80,
+    borderRadius: theme.borderRadius.sm,
+  },
+  addImage: {
+    width: 80,
+    height: 80,
+    borderRadius: theme.borderRadius.sm,
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    borderColor: theme.colors.primary.main,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  addImageText: {
+    fontSize: 32,
+    color: theme.colors.primary.main,
+  },
+});
+
+export default RequestQuoteScreen;

--- a/src/utils/quoteService.ts
+++ b/src/utils/quoteService.ts
@@ -1,0 +1,26 @@
+import { supabase } from './supabaseClient';
+
+export interface QuoteRequest {
+  title: string;
+  description: string;
+  zip: string;
+  images: string[];
+}
+
+export interface QuoteResponse {
+  businesses: any[];
+  smsResults: Record<string, unknown>[];
+  callResults: Record<string, unknown>[];
+  emailResults: Record<string, unknown>[];
+  diyEstimate?: string | null;
+}
+
+export const requestQuotes = async (
+  payload: QuoteRequest,
+): Promise<QuoteResponse> => {
+  const { data, error } = await supabase.functions.invoke('request-quotes', {
+    body: payload,
+  });
+  if (error) throw error;
+  return data;
+};

--- a/supabase/functions/request-quotes/index.ts
+++ b/supabase/functions/request-quotes/index.ts
@@ -1,0 +1,190 @@
+import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
+
+const GOOGLE_API_KEY = Deno.env.get('GOOGLE_API_KEY');
+const OPENAI_API_KEY = Deno.env.get('OPENAI_API_KEY');
+const TWILIO_ACCOUNT_SID = Deno.env.get('TWILIO_ACCOUNT_SID');
+const TWILIO_AUTH_TOKEN = Deno.env.get('TWILIO_AUTH_TOKEN');
+const TWILIO_FROM_NUMBER = Deno.env.get('TWILIO_FROM_NUMBER');
+const SENDGRID_API_KEY = Deno.env.get('SENDGRID_API_KEY');
+const SENDGRID_FROM_EMAIL = Deno.env.get('SENDGRID_FROM_EMAIL');
+
+serve(async (req) => {
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 });
+  }
+
+  const {
+    title,
+    description,
+    zip,
+    images = [],
+    businessLimit = 5,
+  } = await req.json();
+
+  let businesses: { name: string; phone?: string; email?: string }[] = [];
+  if (GOOGLE_API_KEY) {
+    const searchRes = await fetch(
+      `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${encodeURIComponent(
+        title + ' in ' + zip,
+      )}&key=${GOOGLE_API_KEY}`,
+    );
+    if (searchRes.ok) {
+      const searchData = await searchRes.json();
+      const placeIds = (searchData.results ?? [])
+        .slice(0, businessLimit)
+        .map((p: any) => p.place_id);
+      for (const id of placeIds) {
+        const detailsRes = await fetch(
+          `https://maps.googleapis.com/maps/api/place/details/json?place_id=${id}&fields=name,formatted_phone_number,website&key=${GOOGLE_API_KEY}`,
+        );
+        if (detailsRes.ok) {
+          const detailsData = await detailsRes.json();
+          const res = detailsData.result;
+          if (res) {
+            let email: string | undefined;
+            if (res.website) {
+              try {
+                const siteRes = await fetch(res.website);
+                if (siteRes.ok) {
+                  const html = await siteRes.text();
+                  const match = html.match(/[\w.-]+@[\w.-]+\.[A-Za-z]{2,}/);
+                  if (match) {
+                    email = match[0];
+                  }
+                }
+              } catch (_) {
+                /* ignore */
+              }
+            }
+            businesses.push({
+              name: res.name,
+              phone: res.formatted_phone_number,
+              email,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  const message = `${title}: ${description}\n${images.join(', ')}`;
+  let diyEstimate: string | null = null;
+  if (OPENAI_API_KEY) {
+    const oaRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You estimate time, effort and cost for homeowners doing projects themselves.',
+          },
+          {
+            role: 'user',
+            content: `Provide an estimate of time, effort level and expected price range to DIY this job: ${title}. Details: ${description}`,
+          },
+        ],
+      }),
+    });
+    if (oaRes.ok) {
+      const oaData = await oaRes.json();
+      diyEstimate = oaData.choices?.[0]?.message?.content ?? null;
+    }
+  }
+
+  const smsResults: Record<string, unknown>[] = [];
+  const callResults: Record<string, unknown>[] = [];
+  const emailResults: Record<string, unknown>[] = [];
+
+  if (
+    TWILIO_ACCOUNT_SID &&
+    TWILIO_AUTH_TOKEN &&
+    TWILIO_FROM_NUMBER &&
+    businesses.length
+  ) {
+    for (const biz of businesses) {
+      if (!biz.phone) continue;
+      const auth = btoa(`${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}`);
+
+      // send SMS
+      const smsUrl = `https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json`;
+      const smsBody = new URLSearchParams({
+        From: TWILIO_FROM_NUMBER,
+        To: biz.phone,
+        Body: message,
+      });
+      const smsRes = await fetch(smsUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${auth}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: smsBody,
+      });
+      const smsData = await smsRes.json();
+      smsResults.push({
+        business: biz.name,
+        status: smsRes.status,
+        id: smsData.sid,
+      });
+
+      // voice call
+      const callUrl = `https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Calls.json`;
+      const callBody = new URLSearchParams({
+        From: TWILIO_FROM_NUMBER,
+        To: biz.phone,
+        Twiml: `<Response><Say>${message}</Say></Response>`,
+      });
+      const callRes = await fetch(callUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${auth}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: callBody,
+      });
+      const callData = await callRes.json();
+      callResults.push({
+        business: biz.name,
+        status: callRes.status,
+        id: callData.sid,
+      });
+    }
+  }
+
+  if (SENDGRID_API_KEY && SENDGRID_FROM_EMAIL && businesses.length) {
+    for (const biz of businesses) {
+      if (!biz.email) continue;
+      const emailRes = await fetch('https://api.sendgrid.com/v3/mail/send', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${SENDGRID_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          personalizations: [{ to: [{ email: biz.email }] }],
+          from: { email: SENDGRID_FROM_EMAIL },
+          subject: `Quote request: ${title}`,
+          content: [{ type: 'text/plain', value: message }],
+        }),
+      });
+      emailResults.push({ business: biz.name, status: emailRes.status });
+    }
+  }
+
+  return new Response(
+    JSON.stringify({
+      businesses,
+      smsResults,
+      callResults,
+      emailResults,
+      diyEstimate,
+    }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+});


### PR DESCRIPTION
## Summary
- add quote request edge function
- add quote service util
- add RequestQuote screen
- show RequestQuote button on todos
- register route in navigation
- switch to Google Places instead of Yelp for business lookup
- estimate DIY cost/time via OpenAI
- contact businesses with SMS, voice calls, and email if info available

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6858bb7d26948328824ed574162ef2cc