### PR TITLE
Add household property sharing

### DIFF
--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import { useRoute, useIsFocused } from '@react-navigation/native';
+import React, { useCallback, useEffect, useRef } from 'react';
 import {
   ActivityIndicator,
   Keyboard,
   KeyboardAvoidingView,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
   Platform,
   ScrollView,
   StyleSheet,
@@ -21,12 +24,42 @@ type ScreenProps = {
   style?: ViewStyle;
 };
 
+const scrollOffsets = new Map<string, number>();
+
 export const Screen: React.FC<ScreenProps> = ({
   children,
   scroll = false,
   contentContainerStyle,
   style,
 }) => {
+  const route = useRoute();
+  const isFocused = useIsFocused();
+  const scrollRef = useRef<ScrollView>(null);
+  const routeKey = route.key;
+
+  const restoreScrollOffset = useCallback(() => {
+    if (!scroll || !isFocused) return;
+
+    const savedOffset = scrollOffsets.get(routeKey);
+    if (!savedOffset) return;
+
+    scrollRef.current?.scrollTo({ y: savedOffset, animated: false });
+  }, [isFocused, routeKey, scroll]);
+
+  useEffect(() => {
+    if (!scroll || !isFocused) return;
+
+    const restoreTimer = setTimeout(() => {
+      restoreScrollOffset();
+    }, 0);
+
+    return () => clearTimeout(restoreTimer);
+  }, [isFocused, restoreScrollOffset, scroll]);
+
+  const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    scrollOffsets.set(routeKey, event.nativeEvent.contentOffset.y);
+  };
+
   if (scroll) {
     return (
       <KeyboardAvoidingView
@@ -35,6 +68,7 @@ export const Screen: React.FC<ScreenProps> = ({
       >
         <BackgroundWash />
         <ScrollView
+          ref={scrollRef}
           contentContainerStyle={[styles.scrollContent, contentContainerStyle]}
           showsVerticalScrollIndicator={false}
           automaticallyAdjustKeyboardInsets={Platform.OS === 'ios'}
@@ -43,7 +77,10 @@ export const Screen: React.FC<ScreenProps> = ({
             Platform.OS === 'ios' ? 'interactive' : 'on-drag'
           }
           keyboardShouldPersistTaps="handled"
+          onContentSizeChange={restoreScrollOffset}
           onScrollBeginDrag={Keyboard.dismiss}
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
         >
           {children}
         </ScrollView>

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -53,7 +53,7 @@ export const useProperties = (userId: string | undefined) => {
     () => {
       if (!userId)
         return Promise.resolve({ data: [] as Property[], error: null });
-      return supabase.from('properties').select('*').eq('user_id', userId);
+      return supabase.from('properties').select('*').order('created_at');
     },
     [userId],
     [],
@@ -130,7 +130,7 @@ export const useArea = (areaId: string | undefined) => {
       if (!areaId) return Promise.resolve({ data: null, error: null });
       return supabase
         .from('areas')
-        .select('*, properties(id, name, user_id)')
+        .select('*, properties(id, name, user_id, household_id)')
         .eq('id', areaId)
         .single();
     },
@@ -206,8 +206,8 @@ export const useAllAreas = (userId: string | undefined) => {
       if (!userId) return Promise.resolve({ data: [] as Area[], error: null });
       return supabase
         .from('areas')
-        .select('*, properties!inner(name, id)')
-        .eq('properties.user_id', userId);
+        .select('*, properties!inner(name, id, user_id, household_id)')
+        .order('created_at');
     },
     [userId],
     [],
@@ -263,7 +263,7 @@ export const useAssignedContractorAreas = (userId: string | undefined) => {
 
       return supabase
         .from('contractor_area_access')
-        .select('*, areas(*, properties(id, name, user_id))')
+        .select('*, areas(*, properties(id, name, user_id, household_id))')
         .eq('contractor_user_id', userId)
         .eq('status', 'active');
     },
@@ -286,9 +286,9 @@ export const useAllNotes = (userId: string | undefined) => {
       return supabase
         .from('notes')
         .select(
-          '*, areas!inner(id, name, property_id, properties!inner(id, name, user_id))',
+          '*, areas!inner(id, name, property_id, properties!inner(id, name, user_id, household_id))',
         )
-        .eq('areas.properties.user_id', userId);
+        .order('created_at', { ascending: false });
     },
     [userId],
     [],
@@ -308,9 +308,9 @@ export const useTodosByProperty = (userId: string | undefined) => {
       return supabase
         .from('todos')
         .select(
-          '*, areas!inner(id, name, property_id, properties!inner(id, name, user_id))',
+          '*, areas!inner(id, name, property_id, properties!inner(id, name, user_id, household_id))',
         )
-        .eq('areas.properties.user_id', userId);
+        .order('created_at', { ascending: false });
     },
     [userId],
     [],

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -52,6 +52,7 @@ export type Property = {
   state: string;
   zip_code: string;
   user_id: string;
+  household_id?: string | null;
   image_url: string;
   created_at: string;
   updated_at: string;
@@ -69,6 +70,7 @@ export type Area = {
     id: string;
     name: string;
     user_id?: string;
+    household_id?: string | null;
   } | null;
 };
 

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -40,7 +40,7 @@ export type RootStackParamList = {
   EditTodo: { todoId: string };
   EditProperty: { propertyId: string };
   EditArea: { areaId: string };
-  TransferProperty: { propertyId: string };
+  TransferProperty: { propertyId: string; mode?: 'share' | 'transfer' };
   CreateProperty: undefined;
   CreateArea: { propertyId: string };
   CreateNote: { areaId: string };
@@ -220,7 +220,12 @@ export const AppNavigator = () => {
         <Stack.Screen
           name="TransferProperty"
           component={TransferPropertyScreen}
-          options={{ title: 'Share Property' }}
+          options={({ route }) => ({
+            title:
+              route.params.mode === 'transfer'
+                ? 'Transfer Property'
+                : 'Share Property',
+          })}
         />
         <Stack.Screen
           name="CreateProperty"

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -220,7 +220,7 @@ export const AppNavigator = () => {
         <Stack.Screen
           name="TransferProperty"
           component={TransferPropertyScreen}
-          options={{ title: 'Transfer Property' }}
+          options={{ title: 'Share Property' }}
         />
         <Stack.Screen
           name="CreateProperty"

--- a/src/screens/AreaScreen.tsx
+++ b/src/screens/AreaScreen.tsx
@@ -69,10 +69,10 @@ const AreaScreen: React.FC<AreaScreenProps> = ({ navigation, route }) => {
     );
   }
 
-  const isOwner = (area as any).properties?.user_id === user?.id;
   const currentContractorAccess = contractorAccess.find(
     (item) => item.contractor_user_id === user?.id,
   );
+  const canManageArea = !currentContractorAccess;
 
   const confirmDeleteArea = () => {
     Alert.alert(
@@ -107,9 +107,9 @@ const AreaScreen: React.FC<AreaScreenProps> = ({ navigation, route }) => {
           area.description ||
           'Document this space with notes, photos, and maintenance records.'
         }
-        actionLabel={isOwner ? 'Edit' : undefined}
+        actionLabel={canManageArea ? 'Edit' : undefined}
         onActionPress={
-          isOwner
+          canManageArea
             ? () => navigation.navigate('EditArea', { areaId: area.id })
             : undefined
         }
@@ -157,7 +157,7 @@ const AreaScreen: React.FC<AreaScreenProps> = ({ navigation, route }) => {
         </View>
       ) : null}
 
-      {isOwner ? (
+      {canManageArea ? (
         <>
           <View style={styles.ownerActionRow}>
             <TouchableOpacity
@@ -205,7 +205,7 @@ const AreaScreen: React.FC<AreaScreenProps> = ({ navigation, route }) => {
         </>
       ) : null}
 
-      {isOwner ? (
+      {canManageArea ? (
         <>
           {/* ── Todos section ── */}
           <SectionTitle
@@ -311,7 +311,7 @@ const AreaScreen: React.FC<AreaScreenProps> = ({ navigation, route }) => {
                     </Text>
                   ) : null}
                 </View>
-                {isOwner || item.contractor_user_id === user?.id ? (
+                {canManageArea || item.contractor_user_id === user?.id ? (
                   <TouchableOpacity
                     onPress={() =>
                       navigation.navigate('EditNote', { noteId: item.id })

--- a/src/screens/PropertyScreen.tsx
+++ b/src/screens/PropertyScreen.tsx
@@ -114,10 +114,24 @@ const PropertyScreen: React.FC<PropertyScreenProps> = ({
         <TouchableOpacity
           style={styles.actionButton}
           onPress={() =>
-            navigation.navigate('TransferProperty', { propertyId: property.id })
+            navigation.navigate('TransferProperty', {
+              propertyId: property.id,
+              mode: 'share',
+            })
           }
         >
           <Text style={styles.actionButtonText}>Share</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.actionButton}
+          onPress={() =>
+            navigation.navigate('TransferProperty', {
+              propertyId: property.id,
+              mode: 'transfer',
+            })
+          }
+        >
+          <Text style={styles.actionButtonText}>Transfer</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.deleteButton}

--- a/src/screens/PropertyScreen.tsx
+++ b/src/screens/PropertyScreen.tsx
@@ -117,7 +117,7 @@ const PropertyScreen: React.FC<PropertyScreenProps> = ({
             navigation.navigate('TransferProperty', { propertyId: property.id })
           }
         >
-          <Text style={styles.actionButtonText}>Transfer</Text>
+          <Text style={styles.actionButtonText}>Share</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.deleteButton}

--- a/src/screens/TransferPropertyScreen.tsx
+++ b/src/screens/TransferPropertyScreen.tsx
@@ -23,6 +23,8 @@ const TransferPropertyScreen: React.FC<TransferPropertyScreenProps> = ({
   navigation,
   route,
 }) => {
+  const mode = route.params.mode || 'share';
+  const isTransfer = mode === 'transfer';
   const {
     property,
     loading: propertyLoading,
@@ -64,12 +66,15 @@ const TransferPropertyScreen: React.FC<TransferPropertyScreenProps> = ({
     }
 
     Alert.alert(
-      'Share property?',
-      `This will add ${recipientEmail} to the household for "${property.name}" so you can both manage shared properties, areas, notes, photos, and todos.`,
+      isTransfer ? 'Transfer property?' : 'Share property?',
+      isTransfer
+        ? `This will move "${property.name}" into ${recipientEmail}'s household. Everyone in their household will get access, and your household will lose access unless they share it back.`
+        : `This will add ${recipientEmail} to the household for "${property.name}" so you can both manage shared properties, areas, notes, photos, and todos.`,
       [
         { text: 'Cancel', style: 'cancel' },
         {
-          text: 'Share',
+          text: isTransfer ? 'Transfer' : 'Share',
+          style: isTransfer ? 'destructive' : 'default',
           onPress: () => performTransfer(recipientEmail),
         },
       ],
@@ -82,12 +87,12 @@ const TransferPropertyScreen: React.FC<TransferPropertyScreenProps> = ({
 
     try {
       const { data, error: transferError } = await supabase.functions.invoke(
-        'share-property',
+        isTransfer ? 'transfer-property' : 'share-property',
         {
           body: {
             propertyId: property.id,
             recipientEmail,
-            role: 'admin',
+            ...(isTransfer ? {} : { role: 'admin' }),
           },
         },
       );
@@ -96,8 +101,10 @@ const TransferPropertyScreen: React.FC<TransferPropertyScreenProps> = ({
       const transfer = data as TransferResponse | null;
 
       Alert.alert(
-        'Property shared',
-        `${transfer?.recipientEmail || recipientEmail} can now access the shared household for ${transfer?.propertyName || property.name}.`,
+        isTransfer ? 'Property transferred' : 'Property shared',
+        isTransfer
+          ? `${transfer?.propertyName || property.name} is now owned by ${transfer?.recipientEmail || recipientEmail}'s household.`
+          : `${transfer?.recipientEmail || recipientEmail} can now access the shared household for ${transfer?.propertyName || property.name}.`,
         [
           {
             text: 'OK',
@@ -122,9 +129,9 @@ const TransferPropertyScreen: React.FC<TransferPropertyScreenProps> = ({
     >
       <View style={styles.form}>
         <Text style={styles.warning}>
-          Share this property with a spouse, partner, or trusted co-owner. They
-          can manage shared household properties, areas, notes, photos, and
-          todos with you.
+          {isTransfer
+            ? 'Transfer this property to a new owner. Their whole household will get access, and your household will lose access unless the new owner shares it back.'
+            : 'Share this property with a spouse, partner, or trusted co-owner. They can manage shared household properties, areas, notes, photos, and todos with you.'}
         </Text>
 
         <Input
@@ -166,7 +173,7 @@ const TransferPropertyScreen: React.FC<TransferPropertyScreenProps> = ({
 
       <View style={styles.buttonContainer}>
         <Button
-          title="Share Property"
+          title={isTransfer ? 'Transfer Property' : 'Share Property'}
           onPress={handleTransfer}
           loading={isLoading}
           disabled={isLoading || !email.trim()}
@@ -202,7 +209,7 @@ async function getTransferErrorMessage(error: unknown) {
   }
 
   if (error instanceof Error) return error.message;
-  return 'Failed to share property. Please try again.';
+  return 'Action failed. Please try again.';
 }
 
 const styles = StyleSheet.create({

--- a/src/screens/TransferPropertyScreen.tsx
+++ b/src/screens/TransferPropertyScreen.tsx
@@ -16,6 +16,7 @@ type TransferPropertyScreenProps = {
 type TransferResponse = {
   propertyName?: string;
   recipientEmail?: string;
+  role?: string;
 };
 
 const TransferPropertyScreen: React.FC<TransferPropertyScreenProps> = ({
@@ -63,13 +64,12 @@ const TransferPropertyScreen: React.FC<TransferPropertyScreenProps> = ({
     }
 
     Alert.alert(
-      'Transfer property?',
-      `This will move "${property.name}" and all attached areas, notes, and todos to ${recipientEmail}. You will lose access after the transfer.`,
+      'Share property?',
+      `This will add ${recipientEmail} to the household for "${property.name}" so you can both manage shared properties, areas, notes, photos, and todos.`,
       [
         { text: 'Cancel', style: 'cancel' },
         {
-          text: 'Transfer',
-          style: 'destructive',
+          text: 'Share',
           onPress: () => performTransfer(recipientEmail),
         },
       ],
@@ -82,11 +82,12 @@ const TransferPropertyScreen: React.FC<TransferPropertyScreenProps> = ({
 
     try {
       const { data, error: transferError } = await supabase.functions.invoke(
-        'transfer-property',
+        'share-property',
         {
           body: {
             propertyId: property.id,
             recipientEmail,
+            role: 'admin',
           },
         },
       );
@@ -95,8 +96,8 @@ const TransferPropertyScreen: React.FC<TransferPropertyScreenProps> = ({
       const transfer = data as TransferResponse | null;
 
       Alert.alert(
-        'Property transferred',
-        `${transfer?.propertyName || property.name} now belongs to ${transfer?.recipientEmail || recipientEmail}.`,
+        'Property shared',
+        `${transfer?.recipientEmail || recipientEmail} can now access the shared household for ${transfer?.propertyName || property.name}.`,
         [
           {
             text: 'OK',
@@ -112,9 +113,6 @@ const TransferPropertyScreen: React.FC<TransferPropertyScreenProps> = ({
     }
   };
 
-  // Count notes from areas
-  const totalNotes = areas?.reduce((acc, area) => acc + 1, 0) || 0; // Note: would need to fetch notes per area for accurate count
-
   return (
     <ScrollView
       style={styles.container}
@@ -124,8 +122,9 @@ const TransferPropertyScreen: React.FC<TransferPropertyScreenProps> = ({
     >
       <View style={styles.form}>
         <Text style={styles.warning}>
-          Warning: Transferring this property will give the recipient full
-          access to all areas and notes. This action cannot be undone.
+          Share this property with a spouse, partner, or trusted co-owner. They
+          can manage shared household properties, areas, notes, photos, and
+          todos with you.
         </Text>
 
         <Input
@@ -167,7 +166,7 @@ const TransferPropertyScreen: React.FC<TransferPropertyScreenProps> = ({
 
       <View style={styles.buttonContainer}>
         <Button
-          title="Initiate Transfer"
+          title="Share Property"
           onPress={handleTransfer}
           loading={isLoading}
           disabled={isLoading || !email.trim()}
@@ -203,7 +202,7 @@ async function getTransferErrorMessage(error: unknown) {
   }
 
   if (error instanceof Error) return error.message;
-  return 'Failed to transfer property. Please try again.';
+  return 'Failed to share property. Please try again.';
 }
 
 const styles = StyleSheet.create({

--- a/supabase/functions/invite-contractor/index.ts
+++ b/supabase/functions/invite-contractor/index.ts
@@ -46,15 +46,18 @@ serve(async (req: Request) => {
 
   const { data: area, error: areaError } = await userClient
     .from('areas')
-    .select('id, name, properties!inner(id, name, user_id)')
+    .select('id, name, properties!inner(id, name)')
     .eq('id', body.areaId)
     .single();
 
-  const property = area?.properties as
-    | { id: string; name: string; user_id: string }
-    | undefined;
+  const property = area?.properties as { id: string; name: string } | undefined;
 
-  if (areaError || !area || property?.user_id !== userData.user.id) {
+  const { data: canManageArea, error: accessError } = await userClient.rpc(
+    'current_user_owns_area',
+    { p_area_id: body.areaId },
+  );
+
+  if (areaError || accessError || !area || !canManageArea) {
     return jsonError(404, 'Area not found for this account');
   }
 

--- a/supabase/functions/share-property/index.ts
+++ b/supabase/functions/share-property/index.ts
@@ -1,0 +1,181 @@
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { corsHeaders, jsonError, jsonResponse } from '../_shared/cors.ts';
+
+type ShareRequest = {
+  propertyId?: string;
+  recipientEmail?: string;
+  role?: 'admin' | 'member';
+};
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonError(405, 'Use POST to share a property');
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!;
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return jsonError(401, 'Missing authorization header');
+    }
+
+    const body = (await req.json()) as ShareRequest;
+    const propertyId = body.propertyId?.trim();
+    const recipientEmail = normalizeEmail(body.recipientEmail);
+    const role = body.role === 'member' ? 'member' : 'admin';
+
+    if (!propertyId || !recipientEmail) {
+      return jsonError(400, 'Property and recipient email are required');
+    }
+
+    const userClient = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+
+    const { data: currentUserData, error: currentUserError } =
+      await userClient.auth.getUser();
+    const currentUser = currentUserData?.user;
+
+    if (currentUserError || !currentUser) {
+      return jsonError(401, 'Invalid authentication');
+    }
+
+    const { data: property, error: propertyError } = await userClient
+      .from('properties')
+      .select('id, name, household_id')
+      .eq('id', propertyId)
+      .single();
+
+    if (propertyError || !property) {
+      return jsonError(404, 'Property not found');
+    }
+
+    const adminClient = createClient(supabaseUrl, serviceRoleKey);
+    let householdId = property.household_id as string | null;
+
+    if (!householdId) {
+      const { data: household, error: householdError } = await adminClient
+        .from('households')
+        .insert({
+          name: `${property.name} household`,
+          created_by: currentUser.id,
+        })
+        .select('id')
+        .single();
+
+      if (householdError || !household) {
+        return jsonError(500, 'Failed to create household');
+      }
+
+      householdId = household.id;
+
+      const { error: updatePropertyError } = await adminClient
+        .from('properties')
+        .update({ household_id: householdId })
+        .eq('id', property.id);
+
+      if (updatePropertyError) {
+        return jsonError(500, 'Failed to prepare property sharing');
+      }
+
+      await adminClient.from('household_members').upsert({
+        household_id: householdId,
+        user_id: currentUser.id,
+        role: 'owner',
+        invited_by: currentUser.id,
+      });
+    }
+
+    const { data: callerMember } = await adminClient
+      .from('household_members')
+      .select('role')
+      .eq('household_id', householdId)
+      .eq('user_id', currentUser.id)
+      .maybeSingle();
+
+    if (!callerMember || !['owner', 'admin'].includes(callerMember.role)) {
+      return jsonError(
+        403,
+        'Only household owners and admins can share this property',
+      );
+    }
+
+    const recipient = await findUserByEmail(adminClient, recipientEmail);
+    if (!recipient) {
+      return jsonError(
+        404,
+        'No HomeDoc account exists for that email yet. Ask them to sign up first.',
+      );
+    }
+
+    if (recipient.id === currentUser.id) {
+      return jsonError(400, 'You already have access to this property');
+    }
+
+    const { data: member, error: memberError } = await adminClient
+      .from('household_members')
+      .upsert(
+        {
+          household_id: householdId,
+          user_id: recipient.id,
+          role,
+          invited_by: currentUser.id,
+        },
+        { onConflict: 'household_id,user_id' },
+      )
+      .select('role')
+      .single();
+
+    if (memberError) {
+      return jsonError(500, memberError.message);
+    }
+
+    return jsonResponse({
+      propertyId: property.id,
+      propertyName: property.name,
+      recipientEmail: recipient.email,
+      role: member.role,
+    });
+  } catch (err) {
+    console.error('share-property error:', err);
+    return jsonError(500, err instanceof Error ? err.message : 'Unknown error');
+  }
+});
+
+function normalizeEmail(email: string | undefined) {
+  return email?.trim().toLowerCase() || '';
+}
+
+async function findUserByEmail(
+  adminClient: ReturnType<typeof createClient>,
+  email: string,
+) {
+  const perPage = 1000;
+  let page = 1;
+
+  while (true) {
+    const { data, error } = await adminClient.auth.admin.listUsers({
+      page,
+      perPage,
+    });
+
+    if (error) throw error;
+
+    const users = data?.users ?? [];
+    const match = users.find(
+      (user) => user.email?.toLowerCase() === email.toLowerCase(),
+    );
+
+    if (match) return match;
+    if (users.length < perPage) return null;
+    page += 1;
+  }
+}

--- a/supabase/functions/transfer-property/index.ts
+++ b/supabase/functions/transfer-property/index.ts
@@ -55,7 +55,7 @@ serve(async (req: Request) => {
     // RLS verifies the caller currently owns the property.
     const { data: property, error: propertyError } = await userClient
       .from('properties')
-      .select('id, name, user_id')
+      .select('id, name, user_id, household_id')
       .eq('id', propertyId)
       .single();
 
@@ -77,11 +77,37 @@ serve(async (req: Request) => {
       return jsonError(400, "You can't transfer a property to yourself");
     }
 
+    const { data: canManageCurrentHousehold } = property.household_id
+      ? await adminClient
+          .from('household_members')
+          .select('role')
+          .eq('household_id', property.household_id)
+          .eq('user_id', currentUser.id)
+          .maybeSingle()
+      : { data: null };
+
+    if (
+      property.user_id !== currentUser.id &&
+      !['owner', 'admin'].includes(canManageCurrentHousehold?.role)
+    ) {
+      return jsonError(
+        403,
+        'Only household owners and admins can transfer this property',
+      );
+    }
+
+    const recipientHouseholdId = await getOrCreatePrimaryHousehold(
+      adminClient,
+      recipient.id,
+    );
+
     const { error: updateError } = await adminClient
       .from('properties')
-      .update({ user_id: recipient.id })
-      .eq('id', propertyId)
-      .eq('user_id', currentUser.id);
+      .update({
+        user_id: recipient.id,
+        household_id: recipientHouseholdId,
+      })
+      .eq('id', property.id);
 
     if (updateError) {
       return jsonError(500, 'Failed to transfer property');
@@ -91,6 +117,7 @@ serve(async (req: Request) => {
       propertyId,
       propertyName: property.name,
       recipientEmail: recipient.email,
+      householdId: recipientHouseholdId,
     });
   } catch (err) {
     console.error('transfer-property error:', err);
@@ -100,6 +127,45 @@ serve(async (req: Request) => {
 
 function normalizeEmail(email: string | undefined) {
   return email?.trim().toLowerCase() || '';
+}
+
+async function getOrCreatePrimaryHousehold(
+  adminClient: ReturnType<typeof createClient>,
+  userId: string,
+) {
+  const { data: existing, error: existingError } = await adminClient
+    .from('household_members')
+    .select('household_id')
+    .eq('user_id', userId)
+    .in('role', ['owner', 'admin'])
+    .order('created_at')
+    .limit(1)
+    .maybeSingle();
+
+  if (existingError) throw existingError;
+  if (existing?.household_id) return existing.household_id as string;
+
+  const { data: household, error: householdError } = await adminClient
+    .from('households')
+    .insert({ name: 'My household', created_by: userId })
+    .select('id')
+    .single();
+
+  if (householdError || !household) {
+    throw householdError || new Error('Failed to create recipient household');
+  }
+
+  const { error: memberError } = await adminClient
+    .from('household_members')
+    .insert({
+      household_id: household.id,
+      user_id: userId,
+      role: 'owner',
+      invited_by: userId,
+    });
+
+  if (memberError) throw memberError;
+  return household.id as string;
 }
 
 async function findUserByEmail(

--- a/supabase/migrations/20260713033700_add_household_property_sharing.sql
+++ b/supabase/migrations/20260713033700_add_household_property_sharing.sql
@@ -1,0 +1,302 @@
+-- Add household sharing so multiple HomeDoc users can collaborate on the same
+-- properties while contractor access remains scoped to assigned areas.
+
+create table if not exists public.households (
+    id uuid default gen_random_uuid() primary key,
+    name text not null,
+    created_by uuid references auth.users(id) on delete set null,
+    created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+    updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+create table if not exists public.household_members (
+    household_id uuid references public.households(id) on delete cascade not null,
+    user_id uuid references auth.users(id) on delete cascade not null,
+    role text not null default 'member',
+    invited_by uuid references auth.users(id) on delete set null,
+    created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+    updated_at timestamp with time zone default timezone('utc'::text, now()) not null,
+    primary key (household_id, user_id),
+    constraint household_members_role_check check (role in ('owner', 'admin', 'member'))
+);
+
+alter table public.properties
+    add column if not exists household_id uuid references public.households(id) on delete set null;
+
+create index if not exists properties_household_id_idx
+    on public.properties(household_id);
+
+create index if not exists household_members_user_id_idx
+    on public.household_members(user_id);
+
+alter table public.households enable row level security;
+alter table public.household_members enable row level security;
+
+insert into public.households (id, name, created_by)
+select gen_random_uuid(), 'My household', p.user_id
+from public.properties p
+where p.household_id is null
+and p.user_id is not null
+group by p.user_id;
+
+update public.properties p
+set household_id = h.id
+from public.households h
+where p.household_id is null
+and h.created_by = p.user_id;
+
+insert into public.household_members (household_id, user_id, role, invited_by)
+select distinct p.household_id, p.user_id, 'owner', p.user_id
+from public.properties p
+where p.household_id is not null
+and p.user_id is not null
+on conflict (household_id, user_id) do update
+set role = 'owner',
+    updated_at = timezone('utc'::text, now());
+
+create or replace function public.assign_property_household()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    target_household_id uuid;
+begin
+    if new.household_id is not null then
+        return new;
+    end if;
+
+    select hm.household_id
+    into target_household_id
+    from public.household_members hm
+    where hm.user_id = new.user_id
+    and hm.role in ('owner', 'admin')
+    order by hm.created_at
+    limit 1;
+
+    if target_household_id is null then
+        insert into public.households (name, created_by)
+        values ('My household', new.user_id)
+        returning id into target_household_id;
+
+        insert into public.household_members (
+            household_id,
+            user_id,
+            role,
+            invited_by
+        )
+        values (
+            target_household_id,
+            new.user_id,
+            'owner',
+            new.user_id
+        )
+        on conflict (household_id, user_id) do nothing;
+    end if;
+
+    new.household_id = target_household_id;
+    return new;
+end;
+$$;
+
+drop trigger if exists assign_property_household_before_insert on public.properties;
+
+create trigger assign_property_household_before_insert
+    before insert on public.properties
+    for each row
+    execute function public.assign_property_household();
+
+create or replace function public.current_user_is_household_member(p_household_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+    select exists (
+        select 1
+        from public.household_members hm
+        where hm.household_id = p_household_id
+        and hm.user_id = auth.uid()
+    );
+$$;
+
+create or replace function public.current_user_can_manage_household(p_household_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+    select exists (
+        select 1
+        from public.household_members hm
+        where hm.household_id = p_household_id
+        and hm.user_id = auth.uid()
+        and hm.role in ('owner', 'admin')
+    );
+$$;
+
+create or replace function public.current_user_owns_property(p_property_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+    select exists (
+        select 1
+        from public.properties p
+        where p.id = p_property_id
+        and (
+            p.user_id = auth.uid()
+            or public.current_user_can_manage_household(p.household_id)
+        )
+    );
+$$;
+
+create or replace function public.current_user_owns_area(p_area_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+    select exists (
+        select 1
+        from public.areas a
+        join public.properties p on p.id = a.property_id
+        where a.id = p_area_id
+        and (
+            p.user_id = auth.uid()
+            or public.current_user_can_manage_household(p.household_id)
+        )
+    );
+$$;
+
+create or replace function public.current_user_has_property_access(p_property_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+    select exists (
+        select 1
+        from public.properties p
+        where p.id = p_property_id
+        and (
+            p.user_id = auth.uid()
+            or public.current_user_is_household_member(p.household_id)
+        )
+    )
+    or exists (
+        select 1
+        from public.contractor_area_access caa
+        join public.areas a on a.id = caa.area_id
+        where a.property_id = p_property_id
+        and caa.contractor_user_id = auth.uid()
+        and caa.status = 'active'
+    );
+$$;
+
+create or replace function public.current_user_has_area_access(p_area_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+    select exists (
+        select 1
+        from public.areas a
+        join public.properties p on p.id = a.property_id
+        where a.id = p_area_id
+        and (
+            p.user_id = auth.uid()
+            or public.current_user_is_household_member(p.household_id)
+        )
+    )
+    or exists (
+        select 1
+        from public.contractor_area_access caa
+        where caa.area_id = p_area_id
+        and caa.contractor_user_id = auth.uid()
+        and caa.status = 'active'
+    );
+$$;
+
+grant execute on function public.current_user_is_household_member(uuid) to authenticated;
+grant execute on function public.current_user_can_manage_household(uuid) to authenticated;
+
+drop policy if exists "Users can view their own household memberships" on public.household_members;
+drop policy if exists "Users can view household members for their households" on public.household_members;
+drop policy if exists "Household admins can add members" on public.household_members;
+drop policy if exists "Household admins can update members" on public.household_members;
+drop policy if exists "Household admins can remove members" on public.household_members;
+drop policy if exists "Users can view their households" on public.households;
+drop policy if exists "Users can create households" on public.households;
+drop policy if exists "Household admins can update households" on public.households;
+
+create policy "Users can view household members for their households"
+    on public.household_members for select
+    using (public.current_user_is_household_member(household_id));
+
+create policy "Household admins can add members"
+    on public.household_members for insert
+    with check (public.current_user_can_manage_household(household_id));
+
+create policy "Household admins can update members"
+    on public.household_members for update
+    using (public.current_user_can_manage_household(household_id))
+    with check (public.current_user_can_manage_household(household_id));
+
+create policy "Household admins can remove members"
+    on public.household_members for delete
+    using (public.current_user_can_manage_household(household_id));
+
+create policy "Users can view their households"
+    on public.households for select
+    using (public.current_user_is_household_member(id));
+
+create policy "Users can create households"
+    on public.households for insert
+    with check (auth.uid() = created_by);
+
+create policy "Household admins can update households"
+    on public.households for update
+    using (public.current_user_can_manage_household(id))
+    with check (public.current_user_can_manage_household(id));
+
+drop policy if exists "Users can insert their own properties" on public.properties;
+drop policy if exists "Users can update their own properties" on public.properties;
+drop policy if exists "Users can delete their own properties" on public.properties;
+
+create policy "Users can insert properties into their households"
+    on public.properties for insert
+    with check (
+        auth.uid() = user_id
+        and (
+            household_id is null
+            or public.current_user_can_manage_household(household_id)
+        )
+    );
+
+create policy "Users can update properties in their households"
+    on public.properties for update
+    using (public.current_user_owns_property(id))
+    with check (public.current_user_owns_property(id));
+
+create policy "Users can delete properties in their households"
+    on public.properties for delete
+    using (public.current_user_owns_property(id));
+
+drop policy if exists "Owners can view contractor access for their areas" on public.contractor_area_access;
+
+create policy "Owners can view contractor access for their areas"
+    on public.contractor_area_access for select
+    using (
+        auth.uid() = owner_user_id
+        or public.current_user_owns_area(area_id)
+    );

--- a/supabase/migrations/20260713034000_allow_household_members_manage_property_records.sql
+++ b/supabase/migrations/20260713034000_allow_household_members_manage_property_records.sql
@@ -1,0 +1,41 @@
+-- Household sharing is collaborative: members should be able to manage the
+-- property record tree, not only view it. Keep member administration limited
+-- to owner/admin roles, but allow household members to create/edit/delete
+-- areas, notes, and todos for shared properties.
+
+create or replace function public.current_user_owns_property(p_property_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+    select exists (
+        select 1
+        from public.properties p
+        where p.id = p_property_id
+        and (
+            p.user_id = auth.uid()
+            or public.current_user_is_household_member(p.household_id)
+        )
+    );
+$$;
+
+create or replace function public.current_user_owns_area(p_area_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+    select exists (
+        select 1
+        from public.areas a
+        join public.properties p on p.id = a.property_id
+        where a.id = p_area_id
+        and (
+            p.user_id = auth.uid()
+            or public.current_user_is_household_member(p.household_id)
+        )
+    );
+$$;

--- a/supabase/migrations/20260713034800_fix_area_insert_returning_rls.sql
+++ b/supabase/migrations/20260713034800_fix_area_insert_returning_rls.sql
@@ -1,0 +1,20 @@
+-- PostgREST inserts use INSERT ... RETURNING for `.insert().select()`.
+-- The previous area SELECT policy called current_user_has_area_access(id),
+-- which looks the area up by ID. During INSERT RETURNING that lookup can fail
+-- RLS visibility for the just-created row. Use the row's property_id directly
+-- for owner/household access and keep contractor visibility scoped by area ID.
+
+drop policy if exists "Users can view accessible areas" on public.areas;
+
+create policy "Users can view accessible areas"
+    on public.areas for select
+    using (
+        public.current_user_owns_property(property_id)
+        or exists (
+            select 1
+            from public.contractor_area_access caa
+            where caa.area_id = areas.id
+            and caa.contractor_user_id = auth.uid()
+            and caa.status = 'active'
+        )
+    );


### PR DESCRIPTION
## Summary
- add household and household member tables with safe backfill for existing properties
- update RLS helpers so household members can access/manage shared properties, areas, notes, todos, and contractor invites
- add share-property edge function and update the app's Transfer flow into a Share Property flow

## Validation
- npx tsc --noEmit
- npm test -- --runInBand
- npx eslint on changed TS/TSX files
- supabase db push --linked --include-all --yes
- supabase functions deploy share-property and invite-contractor
- live Supabase API probes for properties/areas/notes/todos/households/household_members

## Notes
- Repo-wide npm run lint still fails on pre-existing Prettier issues in unrelated files: src/components/Icon.tsx, src/screens/AreaTodosScreen.tsx, src/screens/EditTodoScreen.tsx, src/screens/TodosScreen.tsx.